### PR TITLE
FIXED: Make install fails due to the missing jquery dependency

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -2,7 +2,7 @@ LIBPL=		doc_html.pl doc_wiki.pl doc_modes.pl doc_register.pl \
 		doc_process.pl doc_index.pl doc_search.pl doc_man.pl \
 		doc_library.pl hooks.pl doc_htmlsrc.pl doc_colour.pl \
 		doc_util.pl doc_access.pl doc_pack.pl
-SUPPORT=	pldoc.css pldoc.js jquery.js pllisting.css pldoc.sty \
+SUPPORT=	pldoc.css pldoc.js pllisting.css pldoc.sty \
 		edit.png private.png public.png reload.png favicon.ico \
 		up.gif source.png h1-bg.png pub-bg.png multi-bg.png \
 		priv-bg.png h2-bg.png editpred.png


### PR DESCRIPTION
(Introduced in commit 6660b872998abb68c629c5e768da60b7eb738af3.)