### PR TITLE
Fix operator parsing in manindex.db

### DIFF
--- a/man_index.pl
+++ b/man_index.pl
@@ -392,7 +392,7 @@ assert_index(Object, Summary, File, Class, Offset) :-
     !,
     map_section(Object1, Object, File),
     symbolic_file(File, Symbolic),
-    format(Out, '~q.~n', [i(Object1, Summary, Symbolic, Class, Offset)]).
+    format(Out, '~k.~n', [i(Object1, Summary, Symbolic, Class, Offset)]).
 assert_index(Object, Summary, File, Class, Offset) :-
     assertz(man_index(Object, Summary, File, Class, Offset)).
 


### PR DESCRIPTION
`clpfd` operators like `#\ /1` are choking the parsing of `manindex.db`:
```prolog
Welcome to SWI-Prolog (threaded, 64 bits, version 7.7.23-9-g85ff8e4b1)
[...]

1 ?- help(help).
Warning: /tmp/s2/lib/swipl/doc/manindex.db:389:7: Syntax error: Operator expected
Warning: No help for help.
Warning: Use ?- apropos(query). to search for candidates.
true.
```

This is because the following type of line is written to `manindex.db`:
```prolog
i(#\ / 1,"Q does not hold.",swi_man_manual('clpfd.html'),manual,65790).
```

This patch solves the problem by writing the canonical form instead:
```prolog
i(/(#\,1),"Q does not hold.",swi_man_manual('clpfd.html'),manual,65790).
```